### PR TITLE
remove 'metadata.json' from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .bundle
 .cache
 .kitchen
-metadata.json
 Gemfile.lock
 Berksfile.lock
 test/kitchen/.kitchen/


### PR DESCRIPTION
If `metadata.json` line in `.gitignore`, then no metadata file (rb or json) stored in repository after `berkshelf vendor`