### PR TITLE
Remove the swap version pin to allow the newer version.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -45,7 +45,7 @@ supports 'redhat'
 supports 'suse'
 supports 'ubuntu'
 
-depends 'swap', '~> 0.3'
+depends 'swap', '~> 2.1'
 
 recipe 'swap_tuning::default', 'Creates the swap file.'
 


### PR DESCRIPTION
The version pinned had a bug that broke swap-tuning.